### PR TITLE
Added nbtscan to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3271,6 +3271,12 @@ nasm:
   macports: [nasm]
   opensuse: [nasm]
   ubuntu: [nasm]
+nbtscan:
+  arch: [nbtscan]
+  debian: [nbtscan]
+  fedora: [nbtscan]
+  gentoo: [net-analyzer/nbtscan]
+  ubuntu: [nbtscan]
 net-tools:
   arch: [net-tools]
   debian: [net-tools]


### PR DESCRIPTION
We use nbtscan (a netbios tool) in one of our projects. Would be nice to have it in the dependencies.

Package sources (I only tested ubuntu) but i think they should be correct.
https://www.archlinux.de/?page=Packages&search=nbtscan
https://packages.debian.org/search?keywords=nbtscan
https://admin.fedoraproject.org/pkgdb/package/rpms/nbtscan/
https://packages.gentoo.org/packages/net-analyzer/nbtscan
https://packages.ubuntu.com/xenial/net/nbtscan